### PR TITLE
Fix oneshots matching

### DIFF
--- a/comixology2/themeScript.js
+++ b/comixology2/themeScript.js
@@ -370,7 +370,7 @@ loadScript(proxyPrefix+"/theme/js/jquery-3.3.1.min.js", function(){
 									
 								}
 								for (i = 0; i < data.oneshots.length; i++) {
-									$(".cellcontainer:has(.label:contains('"+data.oneshots[i]+"'))").appendTo($('#oneshots'));
+									$(".cellcontainer:has(.label:contains('"+data.oneshots[i].replace(/'/g,'\\\'')+"'))").appendTo($('#oneshots'));
 								}
 								if($('#oneshots .cellcontainer').length){
 									$('#oneshots').show();


### PR DESCRIPTION
Fix case where the oneshot name from the JSON file has a single quote in it which messed up the jquery lookup by replace ' with \'.