### PR TITLE
Comic char header

### DIFF
--- a/comixology2/themeScript.js
+++ b/comixology2/themeScript.js
@@ -339,9 +339,17 @@ loadScript(proxyPrefix+"/theme/js/jquery-3.3.1.min.js", function(){
                                     $('#cover').attr('src','?folderinfo=folder.jpg');
                                     $('#publisher, #publisher2').attr('href', $('#arrowup').attr('href'));
 									if(type=="comicChar"){
-										 $('<div align="center"><img id="charHeaderImg" width="1100" height="258"></div>').insertBefore($('.headerSection'));
-										 $('#charHeaderImg').attr('src', '?folderinfo=header.jpg');
-										 $('#group .list-title').text("Series");
+										if(comicCharHeader){
+											$('<div align="center"><img id="charHeaderImg" width="1100" height="258"></div>').insertBefore($('.headerSection'));
+											$('#charHeaderImg').attr('src', '?folderinfo=header.jpg');
+										}else{
+											$(".headerSection").css('background-color', 'rgba(0,0,0,.75)');
+											$(".headerSection").css('background-image', 'url(?folderinfo=header.jpg)');
+											$(".headerSection").css('background-size', 'cover');
+											$(".headerSection").css('background-position','top center');
+											$(".headerSection").css('background-blend-mode','color');
+										}
+										$('#group .list-title').text("Series");
 									}
                                     $('#pubImg').attr('src', $('#arrowup').attr('href')+'?folderinfo=folder.jpg');
 									$('#pubImg').on("error", function(){

--- a/comixology2/themeScript.js
+++ b/comixology2/themeScript.js
@@ -348,6 +348,7 @@ loadScript(proxyPrefix+"/theme/js/jquery-3.3.1.min.js", function(){
 											$(".headerSection").css('background-size', 'cover');
 											$(".headerSection").css('background-position','top center');
 											$(".headerSection").css('background-blend-mode','color');
+											$(".social-links").css('cssText', 'background-color: rgba(0,0,0,.4) !important');
 										}
 										$('#group .list-title').text("Series");
 									}


### PR DESCRIPTION
Update the comicChar pages to either include the previous header before the headerSection, or have the image as a background to the headerSection.  This is dependent a new setting variable in the settings.js file as defined: var comicCharHeader = false; /* Show header.jpg image for comic character pages before headerSection container, otherwise header.jpg will be used as background image in the headerSection container */.  Wasn't sure how to add this since that file isn't in the repo.